### PR TITLE
Drop conflict section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,6 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^5.5 || ^6.2"
     },
-    "conflict": {
-        "symfony/translation": "<2.0 || >4.0",
-        "symfony/symfony": "<2.0 || >4.0"
-    },
     "autoload": {
         "psr-4": {
             "Translation\\Common\\": "src/"


### PR DESCRIPTION
This repo uses only MessageCatalogueInterface from symfony components, which is available since Symfony 2.0. symfony/translation < 2.0 does not exist.

Currently, this packages locks symfony/translation to 4.0.0 and doesn't allow it to update 4.0.2