### PR TITLE
Prepare release 3.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
+## 3.1.0
+
+Added support for PHP8.
+
 ## 3.0.1
 
 Added comments on the `TransferableStorage` interface to describe the options parameter.


### PR DESCRIPTION
I checked out the 3.0.1 release. Added a [small commit](https://github.com/php-translation/common/commit/08b790d4a2b23b5cb52af430571022c847b38dbd) to allow PHP8 in composer.json and pushed it to a 3.x branch. 

If we make a 3.1.0 release of 3.x branch, we are sure we dont break BC and we can keep working in master as normal. 