### PR TITLE
Symfony 7 support 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     },
     "require-dev": {
         "symfony/framework-bundle": " ^3.4 || ^4.3 || ^5.0 || ^6.0 || ^7.0",
-        "phpunit/phpunit": ">=8.5.23"
+        "phpunit/phpunit": ">=8.5.23",
+        "phpspec/prophecy-phpunit": "^2.1"        
     },
     "autoload": {
         "psr-4": {

--- a/tests/Unit/Storage/ChainStorageTest.php
+++ b/tests/Unit/Storage/ChainStorageTest.php
@@ -12,6 +12,7 @@
 namespace Translation\common\tests\Unit\Storage;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Translation\Common\Model\Message;
 use Translation\Common\Storage\ChainStorage;
@@ -19,6 +20,7 @@ use Translation\Common\Storage\StorageInterface;
 
 class ChainStorageTest extends TestCase
 {
+    use ProphecyTrait;
     private $childStorage1;
     private $childStorage2;
     private $storage;

--- a/tests/Unit/Storage/FileStorageTest.php
+++ b/tests/Unit/Storage/FileStorageTest.php
@@ -41,7 +41,7 @@ class FileStorageTest extends TestCase
     public function testCreateNewCatalogue()
     {
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods([$this->getMethodNameToWriteTranslations()])
+            ->onlyMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
         $writer->expects($this->once())
@@ -56,7 +56,7 @@ class FileStorageTest extends TestCase
         $storage->create(new Message('key', 'domain', 'en', 'Message'));
 
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods([$this->getMethodNameToWriteTranslations()])
+            ->onlyMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
         $writer->expects($this->once())
@@ -74,7 +74,7 @@ class FileStorageTest extends TestCase
     public function testCreateExistingCatalogue()
     {
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods([$this->getMethodNameToWriteTranslations()])
+            ->onlyMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
         $writer->expects($this->once())
@@ -117,7 +117,7 @@ class FileStorageTest extends TestCase
     public function testUpdate()
     {
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods([$this->getMethodNameToWriteTranslations()])
+            ->onlyMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
         $writer->expects($this->exactly(2))
@@ -139,7 +139,7 @@ class FileStorageTest extends TestCase
     public function testDelete()
     {
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods([$this->getMethodNameToWriteTranslations()])
+            ->onlyMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -163,7 +163,7 @@ class FileStorageTest extends TestCase
     public function testImport()
     {
         $writer = $this->getMockBuilder(TranslationWriter::class)
-            ->setMethods([$this->getMethodNameToWriteTranslations()])
+            ->onlyMethods([$this->getMethodNameToWriteTranslations()])
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Unit/XliffConverterTest.php
+++ b/tests/Unit/XliffConverterTest.php
@@ -36,6 +36,6 @@ class XliffConverterTest extends TestCase
         $catalogue->add(['foobar' => 'bar']);
         $content = XliffConverter::catalogueToContent($catalogue, 'messages');
 
-        $this->assertRegExp('|foobar|', $content);
+        $this->assertMatchesRegularExpression('/foobar/', $content);
     }
 }


### PR DESCRIPTION
Based on #52 
Tests are fixed except for php 7.2

There is a way to remove support for php 7.2
=> php 7.2 security support ended on 30 Nov 2020